### PR TITLE
prerana/build embedding map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Cached embeddings (large, regenerate via generate-prism-embeddings.py)
 PRISM/data/prism/*.pkl
 
-# Generated experiment results (copy down manually; regenerated per run)
+# Generated reproducibility experiment results (regenerated per run, we might have diffs so don't want unnecessary merge conflicts)
 PRISM/basis_reproducibility_results.csv
+PRISM/basis_detail.csv
 PRISM/basis_matrices.pt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ PRISM/data/prism/*.pkl
 
 # Generated experiment results (copy down manually; regenerated per run)
 PRISM/basis_reproducibility_results.csv
+PRISM/basis_matrices.pt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Cached embeddings (large, regenerate via generate-prism-embeddings.py)
+PRISM/data/prism/*.pkl
+
+# Generated experiment results (copy down manually; regenerated per run)
+PRISM/basis_reproducibility_results.csv

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -66,6 +66,12 @@ Prints a summary table for each part, THEN a PER-CONFIG BASIS DETAIL section
 (one fingerprint row per individual basis vector -- screenshot this to share),
 AND writes:
   - basis_reproducibility_results.csv : the summary rows (gitignored)
+  - basis_detail.csv                  : the eyeball view -- one row PER BASIS
+                                        vector per run (norm, cos to V_sft,
+                                        checksum, max user weight, kept). Same
+                                        numbers as the BASIS DETAIL tables, so
+                                        you can diff/sort in a spreadsheet instead
+                                        of squinting at a screenshot (gitignored).
   - basis_matrices.pt                 : a self-contained dict per run, keyed by run
                                         (e.g. PART2_K10_seed42). Each entry holds
                                         the FULL [4096, K] basis matrix V, the full
@@ -247,9 +253,16 @@ def print_basis_detail(key, m, vsft):
               f"{'checksum':>13} | {'max_user_wt':>11} | {'kept':>4}")
     print(header)
     print("-" * len(header))
+    detail_rows = []
     for idx, (norm, cos, checksum, max_wt, kept) in enumerate(rows):
         print(f"{idx:>5} | {norm:>12.5f} | {cos:>11.5f} | {checksum:>13.5f} | "
               f"{max_wt:>11.5f} | {'yes' if kept else 'no':>4}")
+        detail_rows.append({
+            "run_key": key, "part": m["part"], "K": K, "seed": m["seed"],
+            "basis": idx, "norm": norm, "cos_vsft": cos, "checksum": checksum,
+            "max_user_wt": max_wt, "kept": "yes" if kept else "no",
+        })
+    return detail_rows
 
 
 def parse_args():
@@ -279,6 +292,10 @@ def parse_args():
                    help="path to save the FULL [4096,K] basis matrix per run "
                         "(gitignored; copy down to inspect/compare ALL bases, "
                         "including sub-threshold ones)")
+    p.add_argument("--detail-out", default="basis_detail.csv",
+                   help="CSV path for the per-basis eyeball view (one row per "
+                        "basis vector: norm, cos to V_sft, checksum, max user "
+                        "weight, kept; gitignored; copy down to share/compare)")
     return p.parse_args()
 
 
@@ -337,8 +354,9 @@ def main():
     print("# Same fit -> same set of rows up to ordering. Raw vectors in the .pt file.")
     print("#" * 80)
     vsft_cpu = V_final.detach().cpu()
+    detail_all = []
     for key in order:
-        print_basis_detail(key, matrices[key], vsft_cpu)
+        detail_all.extend(print_basis_detail(key, matrices[key], vsft_cpu))
 
     # ---- save the FULL basis matrices + weights + metadata per run ----
     torch.save(matrices, args.matrices_out)
@@ -359,6 +377,20 @@ def main():
                 row[k] = f"{row[k]:.4f}"
             writer.writerow(row)
     print(f"\nWrote {len(part1) + len(part2)} rows to {args.out}")
+
+    # ---- write per-basis detail CSV (the eyeball view, one row per basis) ----
+    detail_fields = ["run_key", "part", "K", "seed", "basis",
+                     "norm", "cos_vsft", "checksum", "max_user_wt", "kept"]
+    with open(args.detail_out, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=detail_fields)
+        writer.writeheader()
+        for r in detail_all:
+            row = dict(r)
+            for k in ("norm", "cos_vsft", "checksum", "max_user_wt"):
+                row[k] = f"{row[k]:.5f}"
+            writer.writerow(row)
+    print(f"Wrote {len(detail_all)} per-basis rows to {args.detail_out} "
+          "(same fingerprints as the BASIS DETAIL tables above)")
     print("basis_fp = ||V||_F (permutation/sign-invariant). Compare the PART 2 "
           "seed=42 row against teammates to confirm matching bases.")
 

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -100,7 +100,6 @@ import os
 import sys
 import csv
 import argparse
-import random
 import numpy as np
 import torch
 from collections import defaultdict
@@ -110,18 +109,7 @@ device = "cuda:0" if torch.cuda.is_available() else "cpu"
 # Make utils.py importable (same trick train_basis.py uses)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
-from utils import LoRe_regularized  # noqa: E402
-
-
-def set_seed(s):
-    """Lock every RNG so basis initialization (and the learned bases) is
-    deterministic. This is the fix for LoRe's default non-seeded training that
-    the team agreed on -- without it the bases randomize on every run."""
-    random.seed(s)
-    np.random.seed(s)
-    torch.manual_seed(s)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(s)
+from utils import LoRe_regularized, set_seed  # noqa: E402
 
 
 def group_embeddings_by_user(dataset, seen_value, split_name):

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -1,30 +1,66 @@
 #!/usr/bin/env python3
 """
-LoRe-PRISM basis reproducibility sanity check.
+LoRe-PRISM basis reproducibility sanity check (two-part).
 
-Runs the PRISM basis-learning experiment several times, varying ONE
-hyperparameter, then prints a summary table. The point is a SANITY CHECK:
-teammates run the same command and confirm they all land on the same learned
-basis functions (compare the basis_fp fingerprint column) and the same
-accuracies. Fully argument-driven so it is a single shareable command -- no
-code edits needed to switch what is swept.
+PURPOSE
+-------
+Confirm that everyone on the team learns the SAME basis reward functions from
+the PRISM preference data. Each teammate runs this script and compares the
+`basis_fp` column for the agreed configuration.
 
-Note on basis_fp: it is the Frobenius norm ||V||_F of the learned basis matrix.
-It is invariant to column permutation/sign, so it survives the harmless
-reordering of bases across runs while still flagging a genuinely different fit.
-Expect close-but-not-bitwise-identical values across different GPUs (CUDA
-nondeterminism); same machine + same seed should match tightly.
+The script runs TWO parts in a single invocation:
 
-Prerequisite (one-time, slow): the cached embeddings must already exist:
+  PART 1 - RANK SWEEP  (vary K, hold the seed fixed)
+      Sweeps the number of basis functions K (the rank of V). Shows how
+      generalization accuracy changes with rank. Each row uses a different K,
+      so the learned bases are EXPECTED to differ between rows -- this part is
+      about the rank/accuracy trade-off, not about matching teammates.
+
+  PART 2 - SEED VARIANCE / TEAM REPRODUCIBILITY  (hold K fixed, vary the seed)
+      The original LoRe code does NOT lock the random seed, so the basis
+      initialization -- and therefore the learned bases -- randomizes on every
+      run. We lock it here (see set_seed). Seeds 0,1,2 measure how much the
+      seed actually moves the result; seed 42 is the TEAM-AGREED value. Compare
+      your seed=42 row's basis_fp against your teammates' seed=42 row to confirm
+      you all converge to the same bases.
+
+HYPERPARAMETERS (documented so the script is self-explanatory)
+--------------------------------------------------------------
+  K            number of basis functions = rank of the basis matrix V. The
+               central LoRe knob. (PART 1 sweeps it; PART 2 fixes it.)
+  seed         RNG seed controlling basis initialization during training. MUST
+               match across teammates to reproduce the same bases. Team value = 42.
+  alpha        strength of regularization pulling the bases toward the backbone's
+               single SFT reward direction (V_sft). Default 1e4 (repo default).
+  iters        optimization steps for the alternating W / V solve. Default 20000.
+  lr           learning rate for that solve. Default 0.5.
+  data split   fixed by prepare.py at seed=123. Do NOT change it -- it keeps the
+               train/test user split identical for everyone on the team.
+
+  basis_fp     = ||V||_F, the Frobenius norm of the learned basis matrix. It is
+               invariant to column permutation and sign, so it survives the
+               harmless reordering of bases between runs while still flagging a
+               genuinely different fit. Same GPU + same seed -> matches tightly;
+               different GPUs -> agree to ~3-4 decimals (CUDA float
+               nondeterminism), NOT bitwise. So compare approximately.
+
+PREREQUISITE (one-time, slow): the cached embeddings must already exist at
     data/prism/train_embeddings.pkl
     data/prism/test_embeddings.pkl
 produced by:  python prepare.py  &&  python generate-prism-embeddings.py
 
-Examples (run from inside the PRISM/ directory):
-    python basis_reproducibility_check.py                   # vary K over 5,10,20 (seed 0)
-    python basis_reproducibility_check.py --vary seed       # vary seed over 0,1,2 (K=10)
-    python basis_reproducibility_check.py --vary K --values 1,5,20,50
-    python basis_reproducibility_check.py --vary seed --values 0,1,2,3,4 --fixed-K 5
+OUTPUT
+------
+Prints a summary table for each part AND writes every row to a CSV (default
+basis_reproducibility_results.csv, which is gitignored). Copy that CSV to your
+local machine to share / diff against teammates.
+
+USAGE (run from inside the PRISM/ directory)
+--------------------------------------------
+    python basis_reproducibility_check.py
+    python basis_reproducibility_check.py --rank-values 1,5,10,20,50
+    python basis_reproducibility_check.py --seed-values 0,1,2,42 --fixed-K 10
+    python basis_reproducibility_check.py --out my_results.csv
 """
 import os
 import sys
@@ -43,17 +79,10 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 from utils import solve_regularized_simplex  # noqa: E402
 
 
-def build_runs(args):
-    """Turn CLI args into a list of run configs, sweeping exactly one knob."""
-    if args.vary == "K":
-        values = args.values if args.values is not None else [5, 10, 20]
-        return [{"label": f"K={v}", "K": int(v), "seed": args.fixed_seed} for v in values]
-    else:  # vary == "seed"
-        values = args.values if args.values is not None else [0, 1, 2]
-        return [{"label": f"seed={v}", "K": args.fixed_K, "seed": int(v)} for v in values]
-
-
 def set_seed(s):
+    """Lock every RNG so basis initialization (and the learned bases) is
+    deterministic. This is the fix for LoRe's default non-seeded training that
+    the team agreed on -- without it the bases randomize on every run."""
     random.seed(s)
     np.random.seed(s)
     torch.manual_seed(s)
@@ -105,80 +134,115 @@ def accuracy(W, V, features):
     return float(np.mean(accs)), float(np.std(accs))
 
 
+def run_one(part, label, K, seed, V_final, train_seen, test_seen, args):
+    """Train one basis set under a given (K, seed) and return a result row."""
+    print("\n" + "=" * 64)
+    print(f"[{part}] {label}  (K={K}, seed={seed}, alpha={args.alpha}, "
+          f"iters={args.iters}, lr={args.lr})")
+    print("=" * 64)
+    set_seed(seed)  # lock RNG BEFORE the solve so the basis init is reproducible
+    W, V = solve_regularized_simplex(
+        V_final, args.alpha, train_seen, K,
+        num_iterations=args.iters, learning_rate=args.lr,
+    )
+    train_acc, _ = accuracy(W, V, train_seen)
+    test_acc, test_std = accuracy(W, V, test_seen)
+    return {
+        "part": part, "run": label, "K": K, "seed": seed,
+        "alpha": args.alpha, "iters": args.iters, "lr": args.lr,
+        "bases_kept": V.shape[1],                     # bases surviving pruning
+        "basis_fp": float(torch.linalg.norm(V).item()),  # ||V||_F fingerprint
+        "train_acc": train_acc, "test_acc": test_acc, "test_std": test_std,
+    }
+
+
+def print_table(title, rows):
+    print("\n\n" + "#" * 80)
+    print(f"# {title}")
+    print("#" * 80)
+    header = (f"{'run':>9} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | "
+              f"{'basis_fp':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}")
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(f"{r['run']:>9} | {r['K']:>3} | {r['seed']:>4} | {r['bases_kept']:>10} | "
+              f"{r['basis_fp']:>10.4f} | {r['train_acc']:>9.4f} | "
+              f"{r['test_acc']:>9.4f} | {r['test_std']:>8.4f}")
+
+
 def parse_args():
-    p = argparse.ArgumentParser(description="Run the LoRe-PRISM experiment, sweeping one knob.")
-    p.add_argument("--vary", choices=["K", "seed"], default="K",
-                   help="which hyperparameter to sweep (default: K)")
-    p.add_argument("--values", type=lambda s: [x.strip() for x in s.split(",")], default=None,
-                   help="comma-separated values for the swept knob (e.g. 5,10,20)")
+    p = argparse.ArgumentParser(
+        description="Two-part LoRe-PRISM basis reproducibility check.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    # PART 1 -- rank sweep
+    p.add_argument("--rank-values", type=lambda s: [int(x) for x in s.split(",")],
+                   default=[5, 10, 20],
+                   help="PART 1: comma-separated K values to sweep (seed held fixed)")
+    p.add_argument("--rank-seed", type=int, default=42,
+                   help="PART 1: seed held fixed while sweeping K")
+    # PART 2 -- seed variance / team reproducibility
+    p.add_argument("--seed-values", type=lambda s: [int(x) for x in s.split(",")],
+                   default=[0, 1, 2, 42],
+                   help="PART 2: comma-separated seeds to sweep (42 = team-agreed value)")
     p.add_argument("--fixed-K", type=int, default=10,
-                   help="K to hold fixed when --vary seed (default: 10)")
-    p.add_argument("--fixed-seed", type=int, default=0,
-                   help="seed to hold fixed when --vary K (default: 0)")
-    p.add_argument("--alpha", type=float, default=1e4, help="regularization strength (default: 1e4)")
-    p.add_argument("--iters", type=int, default=20000, help="optimization steps (default: 20000)")
-    p.add_argument("--lr", type=float, default=0.5, help="learning rate (default: 0.5)")
+                   help="PART 2: K held fixed while sweeping the seed")
+    # shared hyperparameters (documented in the module docstring)
+    p.add_argument("--alpha", type=float, default=1e4, help="regularization strength")
+    p.add_argument("--iters", type=int, default=20000, help="optimization steps")
+    p.add_argument("--lr", type=float, default=0.5, help="learning rate")
     p.add_argument("--out", default="basis_reproducibility_results.csv",
-                   help="path to write the summary CSV (default: basis_reproducibility_results.csv)")
+                   help="CSV path for results (gitignored; copy to your machine when done)")
     return p.parse_args()
 
 
 def main():
     args = parse_args()
-    runs = build_runs(args)
 
     print(f"Device: {device}")
-    print(f"Sweep: vary {args.vary} over {[r[args.vary] for r in runs]} "
-          f"| alpha={args.alpha} iters={args.iters} lr={args.lr}")
+    print(f"Hyperparameters: alpha={args.alpha} iters={args.iters} lr={args.lr} "
+          f"(data split fixed by prepare.py seed=123)")
     print("Loading cached embeddings...")
     train_emb = torch.load("data/prism/train_embeddings.pkl")
     test_emb = torch.load("data/prism/test_embeddings.pkl")
-
     train_seen = group_embeddings_by_user(train_emb, seen_value=True, split_name="train")
     test_seen = group_embeddings_by_user(test_emb, seen_value=True, split_name="test")
-    N = len(train_seen)
-    print(f"Seen users: {N}")
+    print(f"Seen users: {len(train_seen)}")
 
     print("Loading backbone once for reference direction (V_sft)...")
     V_final = get_reference_direction()
 
-    results = []
-    for cfg in runs:
-        print("\n" + "=" * 64)
-        print(f"RUN {cfg['label']}  (K={cfg['K']}, seed={cfg['seed']}, alpha={args.alpha}, iters={args.iters})")
-        print("=" * 64)
-        set_seed(cfg["seed"])
-        W, V = solve_regularized_simplex(
-            V_final, args.alpha, train_seen, cfg["K"],
-            num_iterations=args.iters, learning_rate=args.lr,
-        )
-        train_acc, _ = accuracy(W, V, train_seen)
-        test_acc, test_std = accuracy(W, V, test_seen)
-        kept = V.shape[1]  # bases surviving the pruning step
-        basis_fp = float(torch.linalg.norm(V).item())  # ||V||_F fingerprint
-        results.append((cfg["label"], cfg["K"], cfg["seed"], kept, basis_fp, train_acc, test_acc, test_std))
+    # ---- PART 1: rank sweep (vary K, fixed seed) -- bases differ by design ----
+    part1 = [run_one("PART1-rank", f"K={K}", K, args.rank_seed,
+                     V_final, train_seen, test_seen, args)
+             for K in args.rank_values]
 
-    print("\n\n" + "#" * 64)
-    print("# SUMMARY  (test = seen users, UNSEEN prompts -- the generalization metric)")
-    print("#" * 64)
-    header = (f"{'run':>9} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | "
-              f"{'basis_fp':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}")
-    print(header)
-    print("-" * len(header))
-    for label, K, seed, kept, fp, tr, te, std in results:
-        print(f"{label:>9} | {K:>3} | {seed:>4} | {kept:>10} | "
-              f"{fp:>10.4f} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
-    print("\nbasis_fp = ||V||_F (permutation/sign-invariant). Same machine + seed "
-          "should match tightly; teammates compare this to confirm the same bases.")
+    # ---- PART 2: seed variance / team reproducibility (fixed K, vary seed) ----
+    part2 = [run_one("PART2-seed", f"seed={s}", args.fixed_K, s,
+                     V_final, train_seen, test_seen, args)
+             for s in args.seed_values]
 
+    print_table(
+        f"PART 1  RANK SWEEP  (seed fixed at {args.rank_seed}; bases differ between rows by design)",
+        part1)
+    print_table(
+        f"PART 2  SEED VARIANCE  (K fixed at {args.fixed_K}; compare the seed=42 row to teammates)",
+        part2)
+
+    # ---- write combined CSV (gitignored; copy to your machine to share) ----
+    fields = ["part", "run", "K", "seed", "alpha", "iters", "lr",
+              "bases_kept", "basis_fp", "train_acc", "test_acc", "test_std"]
     with open(args.out, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["run", "K", "seed", "bases_kept", "basis_fp",
-                         "train_acc", "test_acc", "test_std"])
-        for label, K, seed, kept, fp, tr, te, std in results:
-            writer.writerow([label, K, seed, kept,
-                             f"{fp:.4f}", f"{tr:.4f}", f"{te:.4f}", f"{std:.4f}"])
-    print(f"\nWrote results to {args.out}")
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for r in part1 + part2:
+            row = dict(r)
+            for k in ("basis_fp", "train_acc", "test_acc", "test_std"):
+                row[k] = f"{row[k]:.4f}"
+            writer.writerow(row)
+    print(f"\nWrote {len(part1) + len(part2)} rows to {args.out}")
+    print("basis_fp = ||V||_F (permutation/sign-invariant). Compare the PART 2 "
+          "seed=42 row against teammates to confirm matching bases.")
 
 
 if __name__ == "__main__":

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -62,14 +62,26 @@ produced by:  python prepare.py  &&  python generate-prism-embeddings.py
 
 OUTPUT
 ------
-Prints a summary table for each part AND writes:
+Prints a summary table for each part, THEN a PER-CONFIG BASIS DETAIL section
+(one fingerprint row per individual basis vector -- screenshot this to share),
+AND writes:
   - basis_reproducibility_results.csv : the summary rows (gitignored)
-  - basis_matrices.pt                 : the FULL [4096, K] basis matrix for every
-                                        run, keyed by run (e.g. PART2_K10_seed42),
-                                        so you can load and compare the actual
-                                        basis vectors -- including sub-threshold
-                                        ones -- not just the scalar fingerprint.
+  - basis_matrices.pt                 : a self-contained dict per run, keyed by run
+                                        (e.g. PART2_K10_seed42). Each entry holds
+                                        the FULL [4096, K] basis matrix V, the full
+                                        [num_users, K] user weights W, and all the
+                                        summary metadata -- so every number in the
+                                        printout (and the per-basis detail) is
+                                        derivable from this file alone. Load and
+                                        compare the actual basis vectors directly,
+                                        including sub-threshold ones.
 Both are gitignored; copy them to your local machine to share / compare.
+
+The 4096-dim basis vectors are too long to print in full, so the PER-CONFIG
+BASIS DETAIL table prints, for each of the K bases, a set of order-/sign-aware
+fingerprints (norm, alignment to V_sft, checksum, max user weight, kept?). Two
+runs that learned the same bases produce the same set of rows (up to ordering);
+the raw vectors themselves live in basis_matrices.pt for exact comparison.
 
 USAGE (run from inside the PRISM/ directory)
 --------------------------------------------
@@ -165,8 +177,9 @@ def run_one(part, label, K, seed, V_final, train_seen, test_seen, args):
     # would only hand back the pruned columns, hiding the sub-threshold bases.
     am = LoRe_regularized(V_final, args.alpha, len(train_seen), 4096, K,
                           args.iters, args.lr)
-    W_kept, V_kept = am.train(train_seen)   # pruned: what downstream eval uses
-    V_full = am.V.detach()                  # [4096, K] -- every basis column
+    W_kept, V_kept = am.train(train_seen)            # pruned: what eval uses
+    V_full = am.V.detach()                           # [4096, K] every basis column
+    W_full = torch.softmax(am.W, dim=1).detach()     # [num_users, K] full weights
 
     # Accuracy uses the pruned (canonical) bases; the dropped near-zero-weight
     # columns add ~nothing, so this matches the repo's reported metric.
@@ -179,7 +192,7 @@ def run_one(part, label, K, seed, V_final, train_seen, test_seen, args):
         "basis_fp": float(torch.linalg.norm(V_full).item()),  # ||V||_F over ALL K cols
         "train_acc": train_acc, "test_acc": test_acc, "test_std": test_std,
     }
-    return row, V_full.cpu()
+    return row, V_full.cpu(), W_full.cpu()
 
 
 def print_table(title, rows):
@@ -194,6 +207,49 @@ def print_table(title, rows):
         print(f"{r['run']:>9} | {r['K']:>3} | {r['seed']:>4} | {r['bases_kept']:>10} | "
               f"{r['basis_fp']:>10.4f} | {r['train_acc']:>9.4f} | "
               f"{r['test_acc']:>9.4f} | {r['test_std']:>8.4f}")
+
+
+def print_basis_detail(key, m, vsft):
+    """Pretty-print one fingerprint row per individual basis vector for a run.
+
+    The full 4096-dim vectors can't be printed legibly, so for each basis column
+    V[:, i] we print order-/sign-aware fingerprints that two identical fits will
+    reproduce (up to column ordering):
+      norm         ||V[:, i]||         -- magnitude of the basis
+      cos(V_sft)   cosine to the backbone reward direction -- where it points
+      checksum     sum of the entries  -- catches a different vector w/ same norm
+      max_user_wt  max over users of softmax(W)[:, i] -- the pruning criterion
+      kept         yes if max_user_wt >= 1e-2 (survived pruning), else no
+    Rows are sorted by norm (descending) so the ordering is canonical and two
+    teammates' tables line up row-for-row regardless of internal column order.
+    The raw vectors live in basis_matrices.pt for exact element-wise comparison.
+    """
+    V = m["V"]                      # [4096, K]
+    W = m["W"]                      # [num_users, K]
+    vsft = vsft.reshape(-1).to(V.dtype)
+    vsft_unit = vsft / (torch.linalg.norm(vsft) + 1e-12)
+    K = V.shape[1]
+    rows = []
+    for i in range(K):
+        col = V[:, i]
+        norm = float(torch.linalg.norm(col).item())
+        cos = float((col @ vsft_unit / (norm + 1e-12)).item())
+        checksum = float(col.sum().item())
+        max_wt = float(W[:, i].max().item())
+        rows.append((norm, cos, checksum, max_wt, max_wt >= 1e-2))
+    rows.sort(key=lambda r: r[0], reverse=True)
+
+    print("\n\n" + "=" * 78)
+    print(f"  BASIS DETAIL: {key}   "
+          f"(K={K}, bases_kept={m['bases_kept']}, ||V||_F={m['basis_fp']:.4f})")
+    print("=" * 78)
+    header = (f"{'basis':>5} | {'norm':>12} | {'cos(V_sft)':>11} | "
+              f"{'checksum':>13} | {'max_user_wt':>11} | {'kept':>4}")
+    print(header)
+    print("-" * len(header))
+    for idx, (norm, cos, checksum, max_wt, kept) in enumerate(rows):
+        print(f"{idx:>5} | {norm:>12.5f} | {cos:>11.5f} | {checksum:>13.5f} | "
+              f"{max_wt:>11.5f} | {'yes' if kept else 'no':>4}")
 
 
 def parse_args():
@@ -243,21 +299,28 @@ def main():
     V_final = get_reference_direction()
 
     part1, part2 = [], []
-    matrices = {}  # run-key -> full [4096, K] basis matrix, saved for inspection
+    # run-key -> self-contained dict {V[4096,K], W[users,K], **metadata}, so every
+    # printed number is derivable from this file alone.
+    matrices = {}
+    order = []  # preserve run order for the per-config detail printout
 
     # ---- PART 1: rank sweep (vary K, fixed seed) -- bases differ by design ----
     for K in args.rank_values:
-        row, V_full = run_one("PART1-rank", f"K={K}", K, args.rank_seed,
-                              V_final, train_seen, test_seen, args)
+        row, V_full, W_full = run_one("PART1-rank", f"K={K}", K, args.rank_seed,
+                                      V_final, train_seen, test_seen, args)
         part1.append(row)
-        matrices[f"PART1_K{K}_seed{args.rank_seed}"] = V_full
+        key = f"PART1_K{K}_seed{args.rank_seed}"
+        matrices[key] = {"V": V_full, "W": W_full, **row}
+        order.append(key)
 
     # ---- PART 2: seed variance / team reproducibility (fixed K, vary seed) ----
     for s in args.seed_values:
-        row, V_full = run_one("PART2-seed", f"seed={s}", args.fixed_K, s,
-                              V_final, train_seen, test_seen, args)
+        row, V_full, W_full = run_one("PART2-seed", f"seed={s}", args.fixed_K, s,
+                                      V_final, train_seen, test_seen, args)
         part2.append(row)
-        matrices[f"PART2_K{args.fixed_K}_seed{s}"] = V_full
+        key = f"PART2_K{args.fixed_K}_seed{s}"
+        matrices[key] = {"V": V_full, "W": W_full, **row}
+        order.append(key)
 
     print_table(
         f"PART 1  RANK SWEEP  (seed fixed at {args.rank_seed}; bases differ between rows by design)",
@@ -266,11 +329,23 @@ def main():
         f"PART 2  SEED VARIANCE  (K fixed at {args.fixed_K}; compare the seed=42 row to teammates)",
         part2)
 
-    # ---- save the FULL basis matrices (all K columns, pre-pruning) ----
+    # ---- PER-CONFIG BASIS DETAIL: one fingerprint row per basis vector ----
+    # This is the screenshot-and-share view: it surfaces EVERY basis (including
+    # sub-threshold ones) so teammates can confirm they learned the same bases.
+    print("\n\n" + "#" * 80)
+    print("# PER-CONFIG BASIS DETAIL  (one row per basis vector; sorted by norm)")
+    print("# Same fit -> same set of rows up to ordering. Raw vectors in the .pt file.")
+    print("#" * 80)
+    vsft_cpu = V_final.detach().cpu()
+    for key in order:
+        print_basis_detail(key, matrices[key], vsft_cpu)
+
+    # ---- save the FULL basis matrices + weights + metadata per run ----
     torch.save(matrices, args.matrices_out)
-    print(f"\nSaved {len(matrices)} full basis matrices (each [4096, K], "
-          f"pre-pruning) to {args.matrices_out}")
-    print("  load with: torch.load('basis_matrices.pt') -> dict[run_key] = V[4096,K]")
+    print(f"\nSaved {len(matrices)} runs to {args.matrices_out} "
+          f"(each: full V[4096,K], full W[users,K], and metadata)")
+    print("  load with: m = torch.load('basis_matrices.pt'); "
+          "m['PART2_K10_seed42']['V'] -> [4096, K]")
 
     # ---- write combined CSV (gitignored; copy to your machine to share) ----
     fields = ["part", "run", "K", "seed", "alpha", "iters", "lr",

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -37,12 +37,23 @@ HYPERPARAMETERS (documented so the script is self-explanatory)
   data split   fixed by prepare.py at seed=123. Do NOT change it -- it keeps the
                train/test user split identical for everyone on the team.
 
-  basis_fp     = ||V||_F, the Frobenius norm of the learned basis matrix. It is
+  bases_kept   how many of the K basis functions survive pruning: a basis is
+               dropped if EVERY user gives it <1% weight (softmax(W) max < 1e-2,
+               see utils.py). This is informational -- the model often collapses
+               onto fewer "effective" bases than K. It can differ between
+               seeds/machines, which is exactly why it must NOT be the thing you
+               compare.
+
+  basis_fp     = ||V||_F over the FULL [4096, K] basis matrix (ALL K columns,
+               BEFORE pruning) -- so it includes sub-threshold bases and is
+               comparable across teammates even when bases_kept differs. It is
                invariant to column permutation and sign, so it survives the
                harmless reordering of bases between runs while still flagging a
                genuinely different fit. Same GPU + same seed -> matches tightly;
                different GPUs -> agree to ~3-4 decimals (CUDA float
-               nondeterminism), NOT bitwise. So compare approximately.
+               nondeterminism), NOT bitwise. So compare approximately. The full
+               matrices themselves are also saved (see OUTPUT) for direct
+               inspection.
 
 PREREQUISITE (one-time, slow): the cached embeddings must already exist at
     data/prism/train_embeddings.pkl
@@ -51,9 +62,14 @@ produced by:  python prepare.py  &&  python generate-prism-embeddings.py
 
 OUTPUT
 ------
-Prints a summary table for each part AND writes every row to a CSV (default
-basis_reproducibility_results.csv, which is gitignored). Copy that CSV to your
-local machine to share / diff against teammates.
+Prints a summary table for each part AND writes:
+  - basis_reproducibility_results.csv : the summary rows (gitignored)
+  - basis_matrices.pt                 : the FULL [4096, K] basis matrix for every
+                                        run, keyed by run (e.g. PART2_K10_seed42),
+                                        so you can load and compare the actual
+                                        basis vectors -- including sub-threshold
+                                        ones -- not just the scalar fingerprint.
+Both are gitignored; copy them to your local machine to share / compare.
 
 USAGE (run from inside the PRISM/ directory)
 --------------------------------------------
@@ -76,7 +92,7 @@ device = "cuda:0" if torch.cuda.is_available() else "cpu"
 # Make utils.py importable (same trick train_basis.py uses)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
-from utils import solve_regularized_simplex  # noqa: E402
+from utils import LoRe_regularized  # noqa: E402
 
 
 def set_seed(s):
@@ -135,25 +151,35 @@ def accuracy(W, V, features):
 
 
 def run_one(part, label, K, seed, V_final, train_seen, test_seen, args):
-    """Train one basis set under a given (K, seed) and return a result row."""
+    """Train one basis set under a given (K, seed). Returns (row, V_full) where
+    V_full is the FULL [4096, K] basis matrix BEFORE pruning -- that full matrix
+    is the thing teammates should compare, since pruning can keep a different
+    number of columns on different machines/seeds."""
     print("\n" + "=" * 64)
     print(f"[{part}] {label}  (K={K}, seed={seed}, alpha={args.alpha}, "
           f"iters={args.iters}, lr={args.lr})")
     print("=" * 64)
     set_seed(seed)  # lock RNG BEFORE the solve so the basis init is reproducible
-    W, V = solve_regularized_simplex(
-        V_final, args.alpha, train_seen, K,
-        num_iterations=args.iters, learning_rate=args.lr,
-    )
-    train_acc, _ = accuracy(W, V, train_seen)
-    test_acc, test_std = accuracy(W, V, test_seen)
-    return {
+    # Build the solver directly (instead of solve_regularized_simplex) so we can
+    # grab the FULL basis matrix am.V (all K columns). solve_regularized_simplex
+    # would only hand back the pruned columns, hiding the sub-threshold bases.
+    am = LoRe_regularized(V_final, args.alpha, len(train_seen), 4096, K,
+                          args.iters, args.lr)
+    W_kept, V_kept = am.train(train_seen)   # pruned: what downstream eval uses
+    V_full = am.V.detach()                  # [4096, K] -- every basis column
+
+    # Accuracy uses the pruned (canonical) bases; the dropped near-zero-weight
+    # columns add ~nothing, so this matches the repo's reported metric.
+    train_acc, _ = accuracy(W_kept, V_kept, train_seen)
+    test_acc, test_std = accuracy(W_kept, V_kept, test_seen)
+    row = {
         "part": part, "run": label, "K": K, "seed": seed,
         "alpha": args.alpha, "iters": args.iters, "lr": args.lr,
-        "bases_kept": V.shape[1],                     # bases surviving pruning
-        "basis_fp": float(torch.linalg.norm(V).item()),  # ||V||_F fingerprint
+        "bases_kept": V_kept.shape[1],                        # survived pruning (info)
+        "basis_fp": float(torch.linalg.norm(V_full).item()),  # ||V||_F over ALL K cols
         "train_acc": train_acc, "test_acc": test_acc, "test_std": test_std,
     }
+    return row, V_full.cpu()
 
 
 def print_table(title, rows):
@@ -193,6 +219,10 @@ def parse_args():
     p.add_argument("--lr", type=float, default=0.5, help="learning rate")
     p.add_argument("--out", default="basis_reproducibility_results.csv",
                    help="CSV path for results (gitignored; copy to your machine when done)")
+    p.add_argument("--matrices-out", default="basis_matrices.pt",
+                   help="path to save the FULL [4096,K] basis matrix per run "
+                        "(gitignored; copy down to inspect/compare ALL bases, "
+                        "including sub-threshold ones)")
     return p.parse_args()
 
 
@@ -212,15 +242,22 @@ def main():
     print("Loading backbone once for reference direction (V_sft)...")
     V_final = get_reference_direction()
 
+    part1, part2 = [], []
+    matrices = {}  # run-key -> full [4096, K] basis matrix, saved for inspection
+
     # ---- PART 1: rank sweep (vary K, fixed seed) -- bases differ by design ----
-    part1 = [run_one("PART1-rank", f"K={K}", K, args.rank_seed,
-                     V_final, train_seen, test_seen, args)
-             for K in args.rank_values]
+    for K in args.rank_values:
+        row, V_full = run_one("PART1-rank", f"K={K}", K, args.rank_seed,
+                              V_final, train_seen, test_seen, args)
+        part1.append(row)
+        matrices[f"PART1_K{K}_seed{args.rank_seed}"] = V_full
 
     # ---- PART 2: seed variance / team reproducibility (fixed K, vary seed) ----
-    part2 = [run_one("PART2-seed", f"seed={s}", args.fixed_K, s,
-                     V_final, train_seen, test_seen, args)
-             for s in args.seed_values]
+    for s in args.seed_values:
+        row, V_full = run_one("PART2-seed", f"seed={s}", args.fixed_K, s,
+                              V_final, train_seen, test_seen, args)
+        part2.append(row)
+        matrices[f"PART2_K{args.fixed_K}_seed{s}"] = V_full
 
     print_table(
         f"PART 1  RANK SWEEP  (seed fixed at {args.rank_seed}; bases differ between rows by design)",
@@ -228,6 +265,12 @@ def main():
     print_table(
         f"PART 2  SEED VARIANCE  (K fixed at {args.fixed_K}; compare the seed=42 row to teammates)",
         part2)
+
+    # ---- save the FULL basis matrices (all K columns, pre-pruning) ----
+    torch.save(matrices, args.matrices_out)
+    print(f"\nSaved {len(matrices)} full basis matrices (each [4096, K], "
+          f"pre-pruning) to {args.matrices_out}")
+    print("  load with: torch.load('basis_matrices.pt') -> dict[run_key] = V[4096,K]")
 
     # ---- write combined CSV (gitignored; copy to your machine to share) ----
     fields = ["part", "run", "K", "seed", "alpha", "iters", "lr",

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -28,6 +28,7 @@ Examples (run from inside the PRISM/ directory):
 """
 import os
 import sys
+import csv
 import argparse
 import random
 import numpy as np
@@ -117,6 +118,8 @@ def parse_args():
     p.add_argument("--alpha", type=float, default=1e4, help="regularization strength (default: 1e4)")
     p.add_argument("--iters", type=int, default=20000, help="optimization steps (default: 20000)")
     p.add_argument("--lr", type=float, default=0.5, help="learning rate (default: 0.5)")
+    p.add_argument("--out", default="basis_reproducibility_results.csv",
+                   help="path to write the summary CSV (default: basis_reproducibility_results.csv)")
     return p.parse_args()
 
 
@@ -167,6 +170,15 @@ def main():
               f"{fp:>10.4f} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
     print("\nbasis_fp = ||V||_F (permutation/sign-invariant). Same machine + seed "
           "should match tightly; teammates compare this to confirm the same bases.")
+
+    with open(args.out, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["run", "K", "seed", "bases_kept", "basis_fp",
+                         "train_acc", "test_acc", "test_std"])
+        for label, K, seed, kept, fp, tr, te, std in results:
+            writer.writerow([label, K, seed, kept,
+                             f"{fp:.4f}", f"{tr:.4f}", f"{te:.4f}", f"{std:.4f}"])
+    print(f"\nWrote results to {args.out}")
 
 
 if __name__ == "__main__":

--- a/PRISM/basis_reproducibility_check.py
+++ b/PRISM/basis_reproducibility_check.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 """
-Quick LoRe-PRISM experiment runner.
+LoRe-PRISM basis reproducibility sanity check.
 
 Runs the PRISM basis-learning experiment several times, varying ONE
-hyperparameter, then prints a summary table. Fully argument-driven so it is a
-single shareable command -- no code edits needed to switch what is swept.
+hyperparameter, then prints a summary table. The point is a SANITY CHECK:
+teammates run the same command and confirm they all land on the same learned
+basis functions (compare the basis_fp fingerprint column) and the same
+accuracies. Fully argument-driven so it is a single shareable command -- no
+code edits needed to switch what is swept.
+
+Note on basis_fp: it is the Frobenius norm ||V||_F of the learned basis matrix.
+It is invariant to column permutation/sign, so it survives the harmless
+reordering of bases across runs while still flagging a genuinely different fit.
+Expect close-but-not-bitwise-identical values across different GPUs (CUDA
+nondeterminism); same machine + same seed should match tightly.
 
 Prerequisite (one-time, slow): the cached embeddings must already exist:
     data/prism/train_embeddings.pkl
@@ -12,10 +21,10 @@ Prerequisite (one-time, slow): the cached embeddings must already exist:
 produced by:  python prepare.py  &&  python generate-prism-embeddings.py
 
 Examples (run from inside the PRISM/ directory):
-    python run_experiment.py                       # vary K over 5,10,20 (seed 0)
-    python run_experiment.py --vary seed           # vary seed over 0,1,2 (K=10)
-    python run_experiment.py --vary K --values 1,5,20,50
-    python run_experiment.py --vary seed --values 0,1,2,3,4 --fixed-K 5
+    python basis_reproducibility_check.py                   # vary K over 5,10,20 (seed 0)
+    python basis_reproducibility_check.py --vary seed       # vary seed over 0,1,2 (K=10)
+    python basis_reproducibility_check.py --vary K --values 1,5,20,50
+    python basis_reproducibility_check.py --vary seed --values 0,1,2,3,4 --fixed-K 5
 """
 import os
 import sys
@@ -143,16 +152,21 @@ def main():
         train_acc, _ = accuracy(W, V, train_seen)
         test_acc, test_std = accuracy(W, V, test_seen)
         kept = V.shape[1]  # bases surviving the pruning step
-        results.append((cfg["label"], cfg["K"], cfg["seed"], kept, train_acc, test_acc, test_std))
+        basis_fp = float(torch.linalg.norm(V).item())  # ||V||_F fingerprint
+        results.append((cfg["label"], cfg["K"], cfg["seed"], kept, basis_fp, train_acc, test_acc, test_std))
 
     print("\n\n" + "#" * 64)
     print("# SUMMARY  (test = seen users, UNSEEN prompts -- the generalization metric)")
     print("#" * 64)
-    header = f"{'run':>9} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}"
+    header = (f"{'run':>9} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | "
+              f"{'basis_fp':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}")
     print(header)
     print("-" * len(header))
-    for label, K, seed, kept, tr, te, std in results:
-        print(f"{label:>9} | {K:>3} | {seed:>4} | {kept:>10} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
+    for label, K, seed, kept, fp, tr, te, std in results:
+        print(f"{label:>9} | {K:>3} | {seed:>4} | {kept:>10} | "
+              f"{fp:>10.4f} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
+    print("\nbasis_fp = ||V||_F (permutation/sign-invariant). Same machine + seed "
+          "should match tightly; teammates compare this to confirm the same bases.")
 
 
 if __name__ == "__main__":

--- a/PRISM/build_embedding_map.py
+++ b/PRISM/build_embedding_map.py
@@ -1,0 +1,161 @@
+"""
+build_embedding_map.py
+
+Builds a lookup dictionary from the train/test embedding pkl files that maps
+each (user_id, dialog_id, turn_nb) to its embeddings + full conversation text.
+
+Also computes basis scores for every conversation against every basis vector
+and saves the full score matrix.
+
+Usage:
+    python build_embedding_map.py
+
+Outputs:
+    embedding_map.pkl       -- full lookup dict, one entry per conversation turn
+    basis_scores.pkl        -- dict with:
+                                 "keys"   : list of (user_id, dialog_id, turn_nb)
+                                 "scores" : [N, K] tensor of basis scores
+                                 "V"      : [4096, K] basis matrix
+
+"""
+
+import torch
+import pickle
+
+# ── Config ────────────────────────────────────────────────────────────────────
+TRAIN_PKL     = "data/prism/train_embeddings.pkl"
+TEST_PKL      = "data/prism/test_embeddings.pkl"
+BASIS_PT      = "basis_matrices.pt"
+BASIS_RUN_KEY = "PART2_K10_seed42"  # ['PART1_K5_seed42', 'PART1_K10_seed42', 'PART1_K20_seed42','PART2_K10_seed0', 'PART2_K10_seed1', 'PART2_K10_seed2', 'PART2_K10_seed42']
+OUT_MAP       = "embedding_map.pkl"
+OUT_SCORES    = "basis_scores.pkl"
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def load_pkl(path):
+    print(f"Loading {path} ...")
+    data = torch.load(path, map_location="cpu")
+    print(f"  → {len(data)} entries")
+    return data
+
+
+def build_embedding_map(train_data, test_data):
+    """
+    Returns a dict keyed by (user_id, dialog_id, turn_nb).
+    Each value contains:
+        chosen_embedding    [4096] float tensor
+        rejected_embedding  [4096] float tensor
+        diff_embedding      chosen - rejected  [4096]
+        prompt              list of {"role", "content"} dicts
+        chosen_utterance    str
+        rejected_utterance  list[str]
+        user_id, dialog_id, turn_nb, split, seen
+    """
+    embedding_map = {}
+
+    for split_name, dataset in [("train", train_data), ("test", test_data)]:
+        for entry in dataset:
+            info = entry["extra_info"]
+
+            key = (
+                info["user_id"],
+                info["dialog_id"],
+                info["turn_nb"],
+            )
+
+            chosen_emb   = info.get("chosen_conv_embedding")
+            rejected_emb = info.get("rejected_conv_embedding")
+
+            if chosen_emb is None or rejected_emb is None:
+                continue
+
+            if not isinstance(chosen_emb, torch.Tensor):
+                chosen_emb   = torch.tensor(chosen_emb,   dtype=torch.float32)
+                rejected_emb = torch.tensor(rejected_emb, dtype=torch.float32)
+            else:
+                chosen_emb   = chosen_emb.to(torch.float32)
+                rejected_emb = rejected_emb.to(torch.float32)
+
+            embedding_map[key] = {
+                "chosen_embedding":   chosen_emb,
+                "rejected_embedding": rejected_emb,
+                "diff_embedding":     chosen_emb - rejected_emb,
+                "prompt":             entry.get("prompt", []),
+                "chosen_utterance":   info.get("chosen_utterance", ""),
+                "rejected_utterance": info.get("rejected_utterance", []),
+                "user_id":   info["user_id"],
+                "dialog_id": info["dialog_id"],
+                "turn_nb":   info["turn_nb"],
+                "split":     split_name,
+                "seen":      info.get("seen", None),
+            }
+
+    print(f"\nembedding_map: {len(embedding_map)} entries")
+    return embedding_map
+
+
+def score_all_conversations(embedding_map, V):
+    """
+    Score every conversation against every basis vector.
+        score[n, i] = diff_embedding[n] @ V[:, i]
+
+    Returns:
+        keys   : list of (user_id, dialog_id, turn_nb) in row order
+        scores : [N, K] float tensor
+    """
+    K    = V.shape[1]
+    keys = list(embedding_map.keys())
+    N    = len(keys)
+
+    # stack all diff embeddings: [N, 4096]
+    diffs = torch.stack([embedding_map[k]["diff_embedding"] for k in keys])
+
+    # full score matrix: [N, K]
+    scores = diffs @ V
+
+    print(f"  Score matrix shape: {scores.shape}  ({N} conversations × {K} bases)")
+    for i in range(K):
+        col = scores[:, i]
+        print(f"  basis_{i:2d} | min: {col.min():.4f}  max: {col.max():.4f}"
+              f"  mean: {col.mean():.4f}  std: {col.std():.4f}")
+
+    return keys, scores
+
+
+def main():
+    #load embeddings
+    train_data = load_pkl(TRAIN_PKL)
+    test_data  = load_pkl(TEST_PKL)
+
+    #build lookup dict
+    embedding_map = build_embedding_map(train_data, test_data)
+
+    #save embedding map
+    with open(OUT_MAP, "wb") as f:
+        pickle.dump(embedding_map, f)
+    print(f"\nSaved embedding_map → {OUT_MAP}")
+
+    #load basis vectors
+    print(f"\nLoading basis matrices from {BASIS_PT} (run: {BASIS_RUN_KEY}) ...")
+    matrices = torch.load(BASIS_PT, map_location="cpu")
+    V = matrices[BASIS_RUN_KEY]["V"].to(torch.float32)  # [4096, K]
+    print(f"  V shape: {V.shape}")
+
+    #score all conversations against all bases
+    print(f"\nScoring {len(embedding_map)} conversations against {V.shape[1]} bases ...")
+    keys, scores = score_all_conversations(embedding_map, V)
+
+    #save full score matrix
+    with open(OUT_SCORES, "wb") as f:
+        pickle.dump({
+            "keys":   keys,    # list of (user_id, dialog_id, turn_nb)
+            "scores": scores,  # [N, K] tensor
+            "V":      V,       # [4096, K] basis matrix
+        }, f)
+    print(f"\nSaved basis_scores → {OUT_SCORES}")
+    print(f"  keys:   list of {len(keys)} (user_id, dialog_id, turn_nb) tuples")
+    print(f"  scores: {scores.shape} tensor — every conversation × every basis")
+    print(f"  V:      {V.shape} basis matrix")
+
+if __name__ == "__main__":
+    main()

--- a/PRISM/run_experiment.py
+++ b/PRISM/run_experiment.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Quick LoRe-PRISM experiment runner.
+
+Runs the PRISM basis-learning experiment 3 times, varying ONE hyperparameter
+(the number of basis functions K by default), then prints a summary table.
+
+Prerequisite (one-time, slow): the cached embeddings must already exist:
+    data/prism/train_embeddings.pkl
+    data/prism/test_embeddings.pkl
+produced by:  python prepare.py  &&  python generate-prism-embeddings.py
+
+Run from inside the PRISM/ directory:
+    python run_experiment.py
+"""
+import os
+import sys
+import random
+import numpy as np
+import torch
+from collections import defaultdict
+
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+# Make utils.py importable (same trick train_basis.py uses)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+from utils import solve_regularized_simplex  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# EXPERIMENT CONFIG  --  edit these rows to change the experiment.
+# Each run changes ONE knob. Default: vary K (number of basis functions),
+# seed held fixed. To study the seed instead, set all K equal and vary "seed".
+# ---------------------------------------------------------------------------
+ALPHA = 1e4        # regularization strength toward the base reward (fixed)
+NUM_ITERS = 20000  # optimization steps (paper uses 20000; lower => faster)
+LR = 0.5           # learning rate
+
+RUNS = [
+    {"label": "K=5",  "K": 5,  "seed": 0},
+    {"label": "K=10", "K": 10, "seed": 0},
+    {"label": "K=20", "K": 20, "seed": 0},
+]
+# ---------------------------------------------------------------------------
+
+
+def set_seed(s):
+    random.seed(s)
+    np.random.seed(s)
+    torch.manual_seed(s)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(s)
+
+
+def group_embeddings_by_user(dataset, seen_value, split_name):
+    """Per user, stack the (chosen - rejected) embedding diffs into [m_i, 4096]."""
+    grouped = defaultdict(list)
+    for ex in dataset:
+        info = ex.get("extra_info", {})
+        if info.get("seen") == seen_value and info.get("split") == split_name:
+            uid = info.get("user_id")
+            if uid:
+                chosen = torch.tensor(info["chosen_conv_embedding"], dtype=torch.float32, device=device)
+                rejected = torch.tensor(info["rejected_conv_embedding"], dtype=torch.float32, device=device)
+                grouped[uid].append(chosen - rejected)
+    return [torch.stack(grouped[u]) for u in sorted(grouped.keys())]
+
+
+def get_reference_direction():
+    """The single global reward direction = backbone's final linear-layer weight.
+    Used as the regularization anchor (V_sft). Loads the 8B backbone once."""
+    from transformers import AutoModel
+    model_name = "Skywork/Skywork-Reward-Llama-3.1-8B-v0.2"
+    rm = AutoModel.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16,
+        device_map=device,
+        attn_implementation="eager",
+        num_labels=1,
+    )
+    last = None
+    for _, m in rm.named_modules():
+        if isinstance(m, torch.nn.Linear):
+            last = m
+    return last.weight[:, 0].to(device).to(torch.float32).reshape(-1, 1)
+
+
+def accuracy(W, V, features):
+    """Device-safe pairwise accuracy. A pair is correct when the personalized
+    reward of (chosen - rejected) is positive, i.e. chosen scored higher."""
+    accs = []
+    for i, X in enumerate(features):
+        X = X.to(V.device, dtype=V.dtype)
+        scores = X @ (V @ W[i])  # [m_i]
+        accs.append((scores > 0).float().mean().item())
+    return float(np.mean(accs)), float(np.std(accs))
+
+
+def main():
+    print(f"Device: {device}")
+    print("Loading cached embeddings...")
+    train_emb = torch.load("data/prism/train_embeddings.pkl")
+    test_emb = torch.load("data/prism/test_embeddings.pkl")
+
+    train_seen = group_embeddings_by_user(train_emb, seen_value=True, split_name="train")
+    test_seen = group_embeddings_by_user(test_emb, seen_value=True, split_name="test")
+    N = len(train_seen)
+    print(f"Seen users: {N}")
+
+    print("Loading backbone once for reference direction (V_sft)...")
+    V_final = get_reference_direction()
+
+    results = []
+    for cfg in RUNS:
+        print("\n" + "=" * 64)
+        print(f"RUN {cfg['label']}  (K={cfg['K']}, seed={cfg['seed']}, alpha={ALPHA}, iters={NUM_ITERS})")
+        print("=" * 64)
+        set_seed(cfg["seed"])
+        W, V = solve_regularized_simplex(
+            V_final, ALPHA, train_seen, cfg["K"],
+            num_iterations=NUM_ITERS, learning_rate=LR,
+        )
+        train_acc, _ = accuracy(W, V, train_seen)
+        test_acc, test_std = accuracy(W, V, test_seen)
+        kept = V.shape[1]  # bases surviving the pruning step
+        results.append((cfg["label"], cfg["K"], cfg["seed"], kept, train_acc, test_acc, test_std))
+
+    print("\n\n" + "#" * 64)
+    print("# SUMMARY  (test = seen users, UNSEEN prompts -- the generalization metric)")
+    print("#" * 64)
+    header = f"{'run':>7} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}"
+    print(header)
+    print("-" * len(header))
+    for label, K, seed, kept, tr, te, std in results:
+        print(f"{label:>7} | {K:>3} | {seed:>4} | {kept:>10} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/PRISM/run_experiment.py
+++ b/PRISM/run_experiment.py
@@ -2,19 +2,24 @@
 """
 Quick LoRe-PRISM experiment runner.
 
-Runs the PRISM basis-learning experiment 3 times, varying ONE hyperparameter
-(the number of basis functions K by default), then prints a summary table.
+Runs the PRISM basis-learning experiment several times, varying ONE
+hyperparameter, then prints a summary table. Fully argument-driven so it is a
+single shareable command -- no code edits needed to switch what is swept.
 
 Prerequisite (one-time, slow): the cached embeddings must already exist:
     data/prism/train_embeddings.pkl
     data/prism/test_embeddings.pkl
 produced by:  python prepare.py  &&  python generate-prism-embeddings.py
 
-Run from inside the PRISM/ directory:
-    python run_experiment.py
+Examples (run from inside the PRISM/ directory):
+    python run_experiment.py                       # vary K over 5,10,20 (seed 0)
+    python run_experiment.py --vary seed           # vary seed over 0,1,2 (K=10)
+    python run_experiment.py --vary K --values 1,5,20,50
+    python run_experiment.py --vary seed --values 0,1,2,3,4 --fixed-K 5
 """
 import os
 import sys
+import argparse
 import random
 import numpy as np
 import torch
@@ -27,21 +32,15 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 from utils import solve_regularized_simplex  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# EXPERIMENT CONFIG  --  edit these rows to change the experiment.
-# Each run changes ONE knob. Default: vary K (number of basis functions),
-# seed held fixed. To study the seed instead, set all K equal and vary "seed".
-# ---------------------------------------------------------------------------
-ALPHA = 1e4        # regularization strength toward the base reward (fixed)
-NUM_ITERS = 20000  # optimization steps (paper uses 20000; lower => faster)
-LR = 0.5           # learning rate
 
-RUNS = [
-    {"label": "K=5",  "K": 5,  "seed": 0},
-    {"label": "K=10", "K": 10, "seed": 0},
-    {"label": "K=20", "K": 20, "seed": 0},
-]
-# ---------------------------------------------------------------------------
+def build_runs(args):
+    """Turn CLI args into a list of run configs, sweeping exactly one knob."""
+    if args.vary == "K":
+        values = args.values if args.values is not None else [5, 10, 20]
+        return [{"label": f"K={v}", "K": int(v), "seed": args.fixed_seed} for v in values]
+    else:  # vary == "seed"
+        values = args.values if args.values is not None else [0, 1, 2]
+        return [{"label": f"seed={v}", "K": args.fixed_K, "seed": int(v)} for v in values]
 
 
 def set_seed(s):
@@ -96,8 +95,29 @@ def accuracy(W, V, features):
     return float(np.mean(accs)), float(np.std(accs))
 
 
+def parse_args():
+    p = argparse.ArgumentParser(description="Run the LoRe-PRISM experiment, sweeping one knob.")
+    p.add_argument("--vary", choices=["K", "seed"], default="K",
+                   help="which hyperparameter to sweep (default: K)")
+    p.add_argument("--values", type=lambda s: [x.strip() for x in s.split(",")], default=None,
+                   help="comma-separated values for the swept knob (e.g. 5,10,20)")
+    p.add_argument("--fixed-K", type=int, default=10,
+                   help="K to hold fixed when --vary seed (default: 10)")
+    p.add_argument("--fixed-seed", type=int, default=0,
+                   help="seed to hold fixed when --vary K (default: 0)")
+    p.add_argument("--alpha", type=float, default=1e4, help="regularization strength (default: 1e4)")
+    p.add_argument("--iters", type=int, default=20000, help="optimization steps (default: 20000)")
+    p.add_argument("--lr", type=float, default=0.5, help="learning rate (default: 0.5)")
+    return p.parse_args()
+
+
 def main():
+    args = parse_args()
+    runs = build_runs(args)
+
     print(f"Device: {device}")
+    print(f"Sweep: vary {args.vary} over {[r[args.vary] for r in runs]} "
+          f"| alpha={args.alpha} iters={args.iters} lr={args.lr}")
     print("Loading cached embeddings...")
     train_emb = torch.load("data/prism/train_embeddings.pkl")
     test_emb = torch.load("data/prism/test_embeddings.pkl")
@@ -111,14 +131,14 @@ def main():
     V_final = get_reference_direction()
 
     results = []
-    for cfg in RUNS:
+    for cfg in runs:
         print("\n" + "=" * 64)
-        print(f"RUN {cfg['label']}  (K={cfg['K']}, seed={cfg['seed']}, alpha={ALPHA}, iters={NUM_ITERS})")
+        print(f"RUN {cfg['label']}  (K={cfg['K']}, seed={cfg['seed']}, alpha={args.alpha}, iters={args.iters})")
         print("=" * 64)
         set_seed(cfg["seed"])
         W, V = solve_regularized_simplex(
-            V_final, ALPHA, train_seen, cfg["K"],
-            num_iterations=NUM_ITERS, learning_rate=LR,
+            V_final, args.alpha, train_seen, cfg["K"],
+            num_iterations=args.iters, learning_rate=args.lr,
         )
         train_acc, _ = accuracy(W, V, train_seen)
         test_acc, test_std = accuracy(W, V, test_seen)
@@ -128,11 +148,11 @@ def main():
     print("\n\n" + "#" * 64)
     print("# SUMMARY  (test = seen users, UNSEEN prompts -- the generalization metric)")
     print("#" * 64)
-    header = f"{'run':>7} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}"
+    header = f"{'run':>9} | {'K':>3} | {'seed':>4} | {'bases_kept':>10} | {'train_acc':>9} | {'test_acc':>9} | {'test_std':>8}"
     print(header)
     print("-" * len(header))
     for label, K, seed, kept, tr, te, std in results:
-        print(f"{label:>7} | {K:>3} | {seed:>4} | {kept:>10} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
+        print(f"{label:>9} | {K:>3} | {seed:>4} | {kept:>10} | {tr:>9.4f} | {te:>9.4f} | {std:>8.4f}")
 
 
 if __name__ == "__main__":

--- a/PRISM/train_basis.py
+++ b/PRISM/train_basis.py
@@ -84,6 +84,11 @@ V_final = last_linear_layer.weight[:,0].to(device).to(torch.float32).reshape(-1,
 # filename = f"./PRISM/V_ref.pt"
 # torch.save(V_final, filename)
 
+# Lock RNG here: after the (non-deterministic) model load and V_final
+# extraction, and before run_regularized() solves the bases -- so normal
+# training runs are reproducible, not just the dedicated check script.
+set_seed(0)
+
 train_accuracies_joint, seen_user_unseen_prompts_accuracies_joint, few_shot_train_accuracies_few_shot, unseen_user_unseen_prompts_accuracies_few_shot, train_accuracies_joint_std, seen_user_unseen_prompts_accuracies_joint_std, few_shot_train_accuracies_few_shot_std, unseen_user_unseen_prompts_accuracies_few_shot_std = run_regularized(K_list, alpha_list, V_final, train_seen, test_seen, 
                 train_unseen, test_unseen, N, N_unseen, device)
 

--- a/PRISM/train_basis.py
+++ b/PRISM/train_basis.py
@@ -87,7 +87,8 @@ V_final = last_linear_layer.weight[:,0].to(device).to(torch.float32).reshape(-1,
 # Lock RNG here: after the (non-deterministic) model load and V_final
 # extraction, and before run_regularized() solves the bases -- so normal
 # training runs are reproducible, not just the dedicated check script.
-set_seed(0)
+# Seed 42 = the team-agreed canonical value (matches the reproducibility check).
+set_seed(42)
 
 train_accuracies_joint, seen_user_unseen_prompts_accuracies_joint, few_shot_train_accuracies_few_shot, unseen_user_unseen_prompts_accuracies_few_shot, train_accuracies_joint_std, seen_user_unseen_prompts_accuracies_joint_std, few_shot_train_accuracies_few_shot_std, unseen_user_unseen_prompts_accuracies_few_shot_std = run_regularized(K_list, alpha_list, V_final, train_seen, test_seen, 
                 train_unseen, test_unseen, N, N_unseen, device)

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,19 @@ import random
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
+
+def set_seed(s):
+    """Lock every RNG so basis initialization (and the learned bases) is
+    deterministic. Call this after loading the backbone model and immediately
+    before solving, so the basis init RNG state is not perturbed by earlier,
+    non-deterministic model loading."""
+    random.seed(s)
+    np.random.seed(s)
+    torch.manual_seed(s)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(s)
+
+
 def simulate_user(reward_tensor, features, w):
     num_prompts = len(reward_tensor)
     feature_diff = []


### PR DESCRIPTION
Adds 'build_embedding_map.py' to the PRISM pipeline.

- Builds embedding_map.pkl: a lookup dict keyed by (user_id, dialog_id, turn_nb) containing conversation text + chosen/rejected/diff embeddings for every PRISM turn
- Computes basis scores for all N conversations against all K basis vectors
- Saves basis_scores.pkl with the full [N, K] score matrix, ordered keys, and V

Usage: python build_embedding_map.py

Requires:  'train_embeddings.pkl', 'test_embeddings.pkl', 'basis_matrices.pt'
